### PR TITLE
Append missing trailing slash to provided PAPI url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "commander": "^2.9.0",
     "rx-amqplib": "^0.1.2",
     "superagent": "^2.1.0",
+    "url-join": "^1.1.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/src/papi-client.ts
+++ b/src/papi-client.ts
@@ -2,6 +2,7 @@ import {AddressBookMessage, ContactMessage, EventMessage} from "./models";
 import {URL, UUID} from "./types";
 import * as Promise from "bluebird";
 import {get, post, put, Response, SuperAgentRequest} from "superagent";
+import urljoin = require("url-join");
 
 export type RequestBuilder = (url: string, callback?: (err: any, res: Response) => void) => SuperAgentRequest;
 export type BatchId = number;
@@ -144,7 +145,7 @@ export class PapiClient {
     }
 
     private papiUrl(urlSuffix: string): string {
-        return this.apiUrl + this.domainUUID + urlSuffix;
+        return urljoin(this.apiUrl, this.domainUUID, urlSuffix);
     }
 
     private assertBatchHasBeenStarted() {

--- a/tests/papi-client.spec.ts
+++ b/tests/papi-client.spec.ts
@@ -59,6 +59,22 @@ describe("PapiClient", () => {
         mock.clearRoutes();
     });
 
+    describe("providing papi url and domain uuid", () => {
+
+        it ("should append a trailing slash if missing", (done) => {
+            papiClient = new PapiClient("https://OBM/v1", "my-domain", {
+                login: "admin",
+                password: "pwd",
+            });
+            mock.post("https://OBM/v1/my-domain/batches/", (req) => {
+                done();
+                return {body: {id: 123}};
+            });
+
+            papiClient.startBatch();
+        });
+    });
+
     describe("startBatch function", () => {
 
         it("should set the authorization header", (done) => {

--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,8 @@
   "name": "spews-importer-obm",
   "dependencies": {
     "bluebird": "registry:npm/bluebird#3.3.4+20160531224558",
-    "sinon": "registry:npm/sinon#1.16.0+20160723033700"
+    "sinon": "registry:npm/sinon#1.16.0+20160723033700",
+    "url-join": "registry:dt/url-join#0.8.3+20161008173327"
   },
   "globalDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160601211834",


### PR DESCRIPTION
Fix issue https://github.com/linagora/spews-importer-obm/issues/22

Importer is misbehaving when a PAPI base url is provided without trailing slash.